### PR TITLE
Remove field in populate text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"private": false,
-	"version": "0.4.21",
+	"version": "0.4.22",
 	"name": "@zegal/sfdt-utils",
 	"description": "SFDT Utils",
 	"author": "Adam Tombleson <rekarnar@gmail.com>",

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -36,6 +36,8 @@ export const getBookmark = (id, prefix = 'DATA::') => {
 			name: `${prefix}${name}`
 		},
 		{
+			fieldType: 0,
+			hasFieldEnd: true, // Check to make sure the populate removes these fields
 			text: 'REPLACE-ME-' + name
 		},
 		{

--- a/src/sfdt/__tests__/populate.test.js
+++ b/src/sfdt/__tests__/populate.test.js
@@ -36,6 +36,8 @@ describe('SFDT Parser', function() {
 
 		// check replacement went well
 		expect(currentInlines[2].text).toEqual('123');
+		expect(currentInlines[2].fieldType).toBeUndefined();
+		expect(currentInlines[2].hasFieldEnd).toBeUndefined();
 	});
 
 	test('populate when data already exists', function() {

--- a/src/sfdt/populate.ts
+++ b/src/sfdt/populate.ts
@@ -72,6 +72,8 @@ export default (data, sfdt, prefixes = allowedPrefix) => {
 										splitInline.characterFormat.highlightColor = 'NoColor';
 									}
 
+									delete splitInline['fieldType'];
+									delete splitInline['hasFieldEnd'];
 									newInlines.push(splitInline);
 								});
 						} else {


### PR DESCRIPTION
The field type will also start in the text field as we (also) update the text in populate in first inline we find rather than updating the text in the inbetween inline
Hence, in such case, the fieldType will be incomplete and docx will break
@Anthony-Michel @p-mag @kirannbhatt 