### PR TITLE
Fix blank data removing text format

### DIFF
--- a/src/sfdt/populate.ts
+++ b/src/sfdt/populate.ts
@@ -95,14 +95,12 @@ export default (data, sfdt, prefixes = allowedPrefix, blankDataCallback) => {
 							if (inline.name === currentlyProcessing && inline.bookmarkType === 1)
 								doneProcessing[currentlyProcessing] = true;
 							else {
-								if(blankDataCallback) {
-									const blankInline: any = {};
-									blankInline.text = (blankDataCallback && blankDataCallback(currentlyProcessing, inline)) || newInline.text;
-									updateTextFormatFields(blankInline);
-									newInlines.push(blankInline);
-								} else {
-									newInlines.push(newInline);
+								if (blankDataCallback) { 
+									newInline.text = blankDataCallback(currentlyProcessing, inline);
+									updateTextFormatFields(newInline);
 								}
+								
+								newInlines.push(newInline);
 							}
 						}
 					} else {


### PR DESCRIPTION
Issue : 
The logic that replace field id from doctype by ____ to document is also removing text format info, so when we add agreement date into the document, the value has incorrect format